### PR TITLE
adding extra line in gradle.build for texture resource

### DIFF
--- a/teamPufferFish/build.gradle
+++ b/teamPufferFish/build.gradle
@@ -114,3 +114,7 @@ publishing {
         }
     }
 }
+
+sourceSets {
+    main { output.resourcesDir = output.classesDir }
+}

--- a/teamPufferFish/src/main/java/com/project/pufferfish/gui/GameBoard.java
+++ b/teamPufferFish/src/main/java/com/project/pufferfish/gui/GameBoard.java
@@ -235,15 +235,11 @@ public class GameBoard extends GuiScreen {
     public void drawScreen (int mouseX, int mouseY, float partialTicks) {
         xScaled = Math.round((width / 2) / scale);
         yScaled = Math.round((height / 2) / scale);
-
-        this.drawDefaultBackground();
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
         GlStateManager.scale(scale, scale, scale);
         this.mc.getTextureManager().bindTexture(gui);
-        this.drawModalRectWithCustomSizedTexture(xScaled - (xSize / 2), yScaled - (ySize / 2), 0, 0, xSize, ySize, textureWidth, textureHeight); // TODO: Allow offset?
-
+        this.drawModalRectWithCustomSizedTexture(xScaled - (xSize / 2), yScaled - (ySize / 2), 0, 0, xSize, ySize, textureWidth, textureHeight);
         super.drawScreen(mouseX, mouseY, partialTicks);
-
     }
 
     @Override


### PR DESCRIPTION
Just adding one config in gradle.build


one and only solution found...from this 
https://stackoverflow.com/questions/27623326/minecraft-forge-not-loading-textures


result:
<img width="906" alt="Screen Shot 2022-02-21 at 10 34 16 PM" src="https://user-images.githubusercontent.com/28659210/155059581-1d7ad5f7-d46d-4685-ba61-e516351cac81.png">

